### PR TITLE
Adjust GitHub field for all users

### DIFF
--- a/app/Actions/Fortify/UpdateUserProfileInformation.php
+++ b/app/Actions/Fortify/UpdateUserProfileInformation.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Fortify;
 
+use App\Helpers\StringHelper;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
@@ -9,13 +10,18 @@ use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
 
 class UpdateUserProfileInformation implements UpdatesUserProfileInformation
 {
-    protected function removeUrlDomain($url) {
-        $re = '/^(?:https?:\/\/)?(?:[^@\/\n]+@)?(?:www\.)?([^:\/?\n]+)\/?/im';
-        $result = preg_replace($re, '', $url);
+    protected function removeGitUrlDomain($user)
+    {
+        $url = $user;
+        if (StringHelper::checkIfContains($url, "https://github.com/") || StringHelper::checkIfContains($url, "https://github.com/")) {
+            $user = StringHelper::getText("/github.com\/(.*)/i", $url);
+        }
 
-        return $result;
+        $user = str_replace("/", "", $user);
+
+        return $user;
     }
-    
+
     /**
      * Validate and update the given user's profile information.
      *
@@ -37,7 +43,7 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
             'instagram' => ['nullable', 'string', 'max:255'],
             'linkedin' => ['nullable', 'string', 'max:255'],
             'lattes' => ['nullable', 'string', 'max:255'],
-            'website' => ['nullable', 'string', 'max:255']
+            'website' => ['nullable', 'string', 'max:255'],
         ])->validateWithBag('updateProfileInformation');
 
         if (isset($input['photo'])) {
@@ -45,7 +51,7 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
         }
 
         if (isset($input['github'])) {
-            $input['github'] = $this->removeUrlDomain($input['github']);
+            $input['github'] = $this->removeGitUrlDomain($input['github']);
         }
 
         if ($input['email'] !== $user->email &&
@@ -63,7 +69,7 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
                 'instagram' => $input['instagram'],
                 'linkedin' => $input['linkedin'],
                 'lattes' => $input['lattes'],
-                'website' => $input['website']
+                'website' => $input['website'],
             ])->save();
         }
     }

--- a/app/Console/Commands/UpdateGithubFieldCommand.php
+++ b/app/Console/Commands/UpdateGithubFieldCommand.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Helpers\StringHelper;
+use App\Models\User;
+use Illuminate\Console\Command;
+
+class UpdateGithubFieldCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'update-github-field';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Ajusta campo github de usuários que criaram-no erroneamente usando a url completa';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $users = User::all();
+
+        foreach ($users as $user) {
+            $user->github = $this->removeGitUrlDomain($user->github);
+            $user->save();
+        }
+    }
+
+    protected function removeGitUrlDomain($githubUser)
+    {
+        $url = $githubUser;
+        if (StringHelper::checkIfContains($url, "https://github.com/") || StringHelper::checkIfContains($url, "https://github.com/")) {
+            $githubUser = StringHelper::getText("/github.com\/(.*)/i", $url);
+        }
+
+        $githubUser = str_replace("/", "", $githubUser);
+
+        return $githubUser;
+    }
+}

--- a/app/Helpers/StringHelper.php
+++ b/app/Helpers/StringHelper.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Helpers;
+
+class StringHelper
+{
+    /**
+     * Format a federal registration according to its type
+     *
+     * @param $value
+     * @return bool|string
+     * @throws Exception
+     */
+    public static function formatarInscricaoFederal($value)
+    {
+        $value = StringHelper::onlyNumbers($value);
+
+        if (strlen($value) == 10) {
+            $value = str_pad($value, 11, "0", STR_PAD_LEFT);
+        }
+
+        switch (strlen($value)) {
+            case 11:
+                $mask = '###.###.###-##';
+                break;
+            default:
+                $mask = '##.###.###/####-##';
+                break;
+        }
+
+        return StringHelper::mask($value, $mask);
+    }
+
+    /**
+     * Mask a string according to a param $mask
+     * @param $str
+     * @param $mask
+     * @return mixed
+     */
+    public static function mask($str, $mask)
+    {
+        $str = StringHelper::onlyNumbers($str);
+        $str = str_replace(' ', '', $str);
+
+        for ($i = 0; $i < strlen($str); $i++) {
+            $mask_pos = strpos($mask, "#");
+
+            if ($mask_pos === false) {
+                return null;
+            }
+
+            $mask[$mask_pos] = $str[$i];
+        }
+
+        return $mask;
+    }
+
+    /**
+     * remove dots from a string
+     * @param $string
+     * @return null|string
+     */
+    public static function onlyNumbers($string)
+    {
+        return preg_replace('/[^0-9]/i', '', $string);
+    }
+
+    /**
+     * Returns a string with every first letter in upper case
+     * @param $string
+     * @return null|string
+     */
+    public static function firstLetterInUpper($name)
+    {
+        return ucfirst(strtolower($name));
+    }
+
+    /**
+     * Returns a string based on the expression given
+     * @param $string
+     * @param $string
+     * @param $int
+     * @return null|string
+     */
+
+    public static function getText($expression, $string, $position = 1)
+    {
+        preg_match($expression, $string, $result);
+
+        return isset($result[$position]) ? trim($result[$position]) : null;
+    }
+
+    /**
+     * Returns if a string is present into another
+     * @param $string
+     * @param $string
+     * @return bool
+     */
+
+    public static function checkIfContains($haystack, $needles)
+    {
+        foreach ((array) $needles as $needle) {
+            if ($needle !== '' && mb_stripos($haystack, $needle) !== false) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/resources/views/livewire/update-profile-personal-information.blade.php
+++ b/resources/views/livewire/update-profile-personal-information.blade.php
@@ -18,7 +18,7 @@
         <!-- enrollment_id -->
         <div class="col-span-3 sm:col-span-2">
             <x-jet-label for="enrollment_id" value="{{ __('Matrícula') }}" />
-            <x-jet-input id="enrollment_id" type="text" class="mt-1 block w-full" wire:model.defer="state.enrollment_id" />
+            <x-jet-input id="enrollment_id" type="text" class="mt-1 block w-full" placeholder="Ex.: 20211XXXXXX" wire:model.defer="state.enrollment_id" />
             <x-jet-input-error for="enrollment_id" class="mt-2" />
         </div>
 

--- a/resources/views/profile/update-profile-information-form.blade.php
+++ b/resources/views/profile/update-profile-information-form.blade.php
@@ -62,42 +62,42 @@
         <!-- github -->
         <div class="col-span-3 sm:col-span-2">
             <x-jet-label for="github" value="{{ __('Github') }}" />
-            <x-jet-input id="github" type="text" class="mt-1 block w-full" wire:model.defer="state.github" />
+            <x-jet-input id="github" type="text" class="mt-1 block w-full" placeholder="Ex.: meuGithub" wire:model.defer="state.github" />
             <x-jet-input-error for="github" class="mt-2" />
         </div>
 
         <!-- linkedin -->
         <div class="col-span-3 sm:col-span-2">
             <x-jet-label for="linkedin" value="{{ __('LinkedIn') }}" />
-            <x-jet-input id="linkedin" type="text" class="mt-1 block w-full" wire:model.defer="state.linkedin" />
+            <x-jet-input id="linkedin" type="text" class="mt-1 block w-full" placeholder="Ex.: meuLinkedin" wire:model.defer="state.linkedin" />
             <x-jet-input-error for="linkedin" class="mt-2" />
         </div>
 
         <!-- google -->
         <div class="col-span-3 sm:col-span-2">
             <x-jet-label for="google" value="{{ __('Google/Gmail') }}" />
-            <x-jet-input id="google" type="text" class="mt-1 block w-full" wire:model.defer="state.google" />
+            <x-jet-input id="google" type="text" class="mt-1 block w-full" placeholder="Ex.: exemplo@exemplo.com" wire:model.defer="state.google" />
             <x-jet-input-error for="google" class="mt-2" />
         </div>
 
         <!-- twitter -->
         <div class="col-span-3 sm:col-span-2">
             <x-jet-label for="twitter" value="{{ __('Twitter') }}" />
-            <x-jet-input id="twitter" type="text" class="mt-1 block w-full" wire:model.defer="state.twitter" />
+            <x-jet-input id="twitter" type="text" class="mt-1 block w-full" placeholder="Ex.: meuTwitter" wire:model.defer="state.twitter" />
             <x-jet-input-error for="twitter" class="mt-2" />
         </div>
 
         <!-- facebook -->
         <div class="col-span-3 sm:col-span-2">
             <x-jet-label for="facebook" value="{{ __('Facebook') }}" />
-            <x-jet-input id="facebook" type="text" class="mt-1 block w-full" wire:model.defer="state.facebook" />
+            <x-jet-input id="facebook" type="text" class="mt-1 block w-full" placeholder="Ex.: meuFacebook" wire:model.defer="state.facebook" />
             <x-jet-input-error for="facebook" class="mt-2" />
         </div>
 
         <!-- instagram -->
         <div class="col-span-3 sm:col-span-2">
             <x-jet-label for="instagram" value="{{ __('Instagram') }}" />
-            <x-jet-input id="instagram" type="text" class="mt-1 block w-full" wire:model.defer="state.instagram" />
+            <x-jet-input id="instagram" type="text" class="mt-1 block w-full" placeholder="Ex.: meuInstagram" wire:model.defer="state.instagram" />
             <x-jet-input-error for="instagram" class="mt-2" />
         </div>
 

--- a/resources/views/sites/show.blade.php
+++ b/resources/views/sites/show.blade.php
@@ -18,7 +18,7 @@
 
                         <div class="mt-6 text-gray-800">
                             Para utilizar os sites pessoais do curso, você precisa informar seu <a href="https://github.com" class="underline">Github</a> nas <a href="{{ route('profile.show') }}" class="underline">Informações de perfil</a> das Configurações da sua conta.
-                            Se você ainda não tem uma conta no <a href="https://github.com" class="underline">Github</a>, ela é grátil e muito útil. Você pode salvar suas atividades acadêmicas lá, que servirão como um portifólio online (além da página maravilhosa que você terá no site do curso ;).
+                            Se você ainda não tem uma conta no <a href="https://github.com" class="underline">Github</a>, ela é grátis e muito útil. Você pode salvar suas atividades acadêmicas lá, que servirão como um portifólio online (além da página maravilhosa que você terá no site do curso ;).
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Implementado comando para rodar em produção e corrigir o campo github de todos os usuários que o inseriram erroneamente anterior a sanitização do campo na ação de salvar.  Para executá-lo basta rodar:

`php artisan update-github-field`

Mais uma vez utilizei features de outros PRs que submeti anteriormente, espero que de bom, qualquer coisa só chamar @Dovyski .